### PR TITLE
Remove TODAY constant from Item model

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,10 +3,8 @@ class Item < ApplicationRecord
 
   enum status: { incomplete: 0, complete: 1 }
 
-  TODAY = Date.today
-
   def self.due_today
-    where("due <= ?", TODAY)
+    where("due <= ?", Date.today)
   end
 
   def self.for_user(user_id)
@@ -17,6 +15,6 @@ class Item < ApplicationRecord
 
   def set_defaults
     self.status ||= :incomplete
-    self.due ||= TODAY
+    self.due ||= Date.today
   end
 end


### PR DESCRIPTION
When the app runs into a second day, I ~think~ the `TODAY` constant was still referencing the Date it was when initially calculated. This would be correct for the rest of that day, but would lead to the problem I'm experiencing right now where all the times are present, but the `due_today` scope no longer works. 

...there might be another PR tomorrow because this didn't actually fix anything.