### PR TITLE
Configure timezone to be Eastern Time

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,8 @@ module MagicMirrorApi
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    config.time_zone = 'Eastern Time (US & Canada)'
+
     config.middleware.use Rack::Cors do
       allow do
         origins 'http://localhost:8080', 'https://morning-scrubland-12661.herokuapp.com'


### PR DESCRIPTION
I know it's bad practice to change the timezone app-wide from UTC, but I'm only using this app in my living room, and I'm pretty sure my living room isn't changing time zones any time soon. I hope.